### PR TITLE
Auto discovering the actual master and sets the others as slaves.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,6 +67,9 @@ default.redis.config.hash_max_ziplist_entries = 512
 default.redis.config.configure_hash_max_ziplist_value = false
 default.redis.config.hash_max_ziplist_value = 64
 
+# cluster
+default.redis.redis_cluster_name = nil #"redis_cluster"
+
 # replication
 default.redis.replication.enabled = false
 default.redis.replication.redis_replication_role = 'master' # or slave

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -28,6 +28,8 @@ attribute :slaveof,        :kind_of => String, :default => nil
 attribute :slaveof_ip,     :kind_of => String, :default => nil
 attribute :slaveof_port,   :kind_of => Integer, :default => nil
 
+attribute :redis_cluster_name, :kind_of => String, :default => nil
+
 ###
 ## the following configuration settings may only work with a recent redis release
 ###

--- a/resources/sentinel.rb
+++ b/resources/sentinel.rb
@@ -22,6 +22,8 @@ attribute :parallel_syncs,          :kind_of => Fixnum, :default => 1
 attribute :quorum,                  :kind_of => Fixnum, :default => 2
 attribute :port,                    :kind_of => Fixnum, :default => 26379
 
+attribute :redis_cluster_name,      :kind_of => String, :default => nil
+
 # Example generated config
 #sentinel monitor mymaster 127.0.0.1 6379 2
 #sentinel down-after-milliseconds mymaster 60000


### PR DESCRIPTION
Hi all,

**I've implemented this solution for auto discovering the actual master of a cluster, and setting the others as slaves of this master.**

You have to set the attribute `redis_cluster_name` with the same name for all the nodes.

The solution is simple:
  1. Check if the node has the attribute `redis_cluster_name`.
  2. Search for other nodes with:
    *  The same name in the attribute `redis_cluster_name`
    *  and with the `recipe[redis::server]`
    *  and in the same `chef_environment`.
  3. If any, connect to the host found with redis-cli and find the master.
  4. Configure this host as slave of the master.
  5. If no node is found, this node will be the master (first node).

The same thing was done for sentinel.

I did a lot of testing, but it would be nice if you do too.

Thanks,
Michael
