### PR TITLE
Fix LWRP template reference, incorrect symlink path, and redis-extract-source default action

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -91,6 +91,7 @@ end
 def create_config
   redis_service_name = redis_service
   template "#{new_resource.conf_dir}/#{new_resource.name}.conf" do
+    cookbook new_resource.cookbook
     source "redis.conf.erb"
     owner "root"
     group "root"
@@ -129,6 +130,7 @@ def create_service_script
   case new_resource.init_style
   when "init"
     template "/etc/init.d/redis-#{new_resource.name}" do
+      cookbook new_resource.cookbook
       source "redis_init.erb"
       owner "root"
       group "root"

--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -44,7 +44,7 @@ end
 
 ["redis-server", "redis-cli"].each do |item|
   link "/sbin/#{item}" do
-    to "#{node.redis.dst_dir}/#{item}"
+    to "#{node.redis.dst_dir}/bin/#{item}"
     only_if { node.redis.symlink_binaries }
   end
 end

--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -38,7 +38,7 @@ execute "redis-extract-source" do
   command "tar zxf #{Chef::Config.file_cache_path}/#{redis_source_tarball} --strip-components 1 -C #{node.redis.src_dir}"
   creates "#{node.redis.src_dir}/COPYING"
   only_if do File.exist?("#{Chef::Config.file_cache_path}/#{redis_source_tarball}") end
-  action :run
+  action :nothing
   notifies :run, "execute[make-redis]", :immediately
 end
 

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -2,6 +2,8 @@ actions :create,  :destroy
 
 attribute :name,  :kind_of => String, :name_attribute => true
 
+attribute :cookbook, :kind_of => String, :default => 'redis'
+
 attribute :user,  :kind_of => String, :default => "redis"
 attribute :group, :kind_of => String, :default => "redis"
 


### PR DESCRIPTION
Howdy!  I ran into a few issues while using this cookbook, let me know if you'd prefer these to be split out into three separate PR's:

1. When using the Redis LWRP from a wrapper cookbook, I ran into an invalid template reference
2. The default action on redis-extract-source causes bad behavior in some cases
3. The "symlink_binaries" path isn't correct for recent source builds

#### LWRP template references
I ran into this error while using the redis_instance LWRP:

<pre>
Recipe: foobar::none
  * group[redis] action create (up to date)
  * user[redis] action create (up to date)
  * directory[/var/log/redis (bazbat)] action create (up to date)
  * directory[/etc/redis] action create (up to date)
  * directory[/var/lib/redis] action create (up to date)
  * directory[/var/run/redis] action create (up to date)
  * template[/etc/init.d/redis-bazbat] action create
================================================================================
Error executing action `create` on resource 'template[/etc/init.d/redis-bazbat]'
================================================================================

Chef::Exceptions::FileNotFound
------------------------------
Cookbook 'foobar' (12.8.763) does not contain a file at any of these locations:
  templates/ubuntu-10.04/redis_init.erb
  templates/ubuntu/redis_init.erb
  templates/default/redis_init.erb

Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/redis/providers/instance.rb

131:     template "/etc/init.d/redis-#{new_resource.name}" do
132:       source "redis_init.erb"
133:       owner "root"
134:       group "root"
135:       mode 00755
136:       variables new_resource.to_hash
137:     end
138:   when "runit"
</pre>

I was using this as the LWRP reference:

<pre>
include_recipe 'redis::default'
include_recipe 'redis::install'

redis_instance 'bazbat' do
  action :create
end
</pre>

This will provide an attribute that can be adjusted for those that need it, and a default for those that use this out of the box.

#### Default action on redis-extract-source
An incorrectly specified source_url caused a bad file to be created in the #{Chef::Config.file_cache_path}/#{redis_source_tarball} path.  On the next run, the default "action :run" on redis-extract-source caused Chef to error out.  Since there's already a trigger on remote_file, I switched the default action to avoid running into that again.

#### Symlink binary path incorrect
I also had a small issue where I set symlink_binaries to true, and the path was incorrectly linked.  Fixed.